### PR TITLE
Fix: Fixed from and to are reversed

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func run(stdout, stderr io.Writer, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse '--to' value: %w", err)
 	}
-	to = from.UTC() // Convert to UTC for easy comparison with the schedule.
+	to = to.UTC() // Convert to UTC for easy comparison with the schedule.
 
 	// Validation
 	// -----------------


### PR DESCRIPTION
This tool treats the from parameter as a to parameter.

Due to this problem, cronjob searches were not working properly.
Fixed this.